### PR TITLE
Added Python3 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+*.egg-info

--- a/bicop/tests/testNestedDict.py
+++ b/bicop/tests/testNestedDict.py
@@ -6,15 +6,15 @@ from bicop.nestdict import NestedDict
 class NestedDictTests(TestCase):
     def testEmptyConstructor(self):
         n = NestedDict()
-        self.assertEqual(n.keys(), [])
+        self.assertEqual(list(n.keys()), [])
 
     def testFlatCopyConstructor(self):
         n = NestedDict(dict(one='one'))
-        self.assertEqual(n.items(), [('one', 'one')])
+        self.assertEqual(list(n.items()), [('one', 'one')])
 
     def testNestedCopyConstructor(self):
         n = NestedDict(dict(one=dict(two='two')))
-        self.assertEqual(n.items(), [('one', dict(two='two'))])
+        self.assertEqual(list(n.items()), [('one', dict(two='two'))])
 
     def testDirectGetItem(self):
         n = NestedDict(dict(one='one'))
@@ -57,7 +57,7 @@ class NestedDictTests(TestCase):
     def testDirectDelItem(self):
         n = NestedDict(dict(one=dict(two='two')))
         del n['one']
-        self.assertEqual(n.keys(), [])
+        self.assertEqual(list(n.keys()), [])
 
     def testRemoveShallowMissingItem(self):
         n = NestedDict(dict(one=dict(two='two')))
@@ -70,20 +70,20 @@ class NestedDictTests(TestCase):
     def testDeepDelItem(self):
         n = NestedDict(dict(one=dict(two='two')))
         del n['one']['two']
-        self.assertEqual(n.keys(), ['one'])
-        self.assertEqual(n['one'].keys(), [])
+        self.assertEqual(list(n.keys()), ['one'])
+        self.assertEqual(list(n['one'].keys()), [])
 
     def testSmartDeepDelItem(self):
         n = NestedDict(dict(one=dict(two='two')))
         del n['one/two']
-        self.assertEqual(n.keys(), ['one'])
-        self.assertEqual(n['one'].keys(), [])
+        self.assertEqual(list(n.keys()), ['one'])
+        self.assertEqual(list(n['one'].keys()), [])
 
     def testSmartDeepDelItemWithDifferentSeparator(self):
         n = NestedDict(dict(one=dict(two='two')), separator=':')
         del n['one:two']
-        self.assertEqual(n.keys(), ['one'])
-        self.assertEqual(n['one'].keys(), [])
+        self.assertEqual(list(n.keys()), ['one'])
+        self.assertEqual(list(n['one'].keys()), [])
 
     def testSetItem(self):
         n = NestedDict()

--- a/bicop/tests/testUtils.py
+++ b/bicop/tests/testUtils.py
@@ -3,11 +3,11 @@ from bicop.utils import same_type
 from bicop.utils import merge
 
 
-class base:
+class Base(object):
     pass
 
 
-class child(base):
+class Child(Base):
     pass
 
 
@@ -19,8 +19,8 @@ class SameTypeTests(TestCase):
         self.assertEqual(same_type('', 1), False)
 
     def testSubClass(self):
-        self.assertEqual(same_type(base(), child()), True)
-        self.assertEqual(same_type(child(), base()), True)
+        self.assertEqual(same_type(Base, Child), True)
+        self.assertEqual(same_type(Child, Base), True)
 
 
 class MergeTests(TestCase):

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -13,7 +13,10 @@ the appropriate options to ``use_setuptools()``.
 
 This file can also be run as a script to install or upgrade setuptools.
 """
+from __future__ import print_function
 import sys
+import os
+
 DEFAULT_VERSION = "0.6c9"
 DEFAULT_URL     = "http://pypi.python.org/packages/%s/s/setuptools/" % sys.version[:3]
 
@@ -54,18 +57,16 @@ md5_data = {
     'setuptools-0.6c9-py2.6.egg': 'ca37b1ff16fa2ede6e19383e7b59245a',
 }
 
-import sys, os
-try: from hashlib import md5
-except ImportError: from md5 import md5
+try:
+    from hashlib import md5
+except ImportError:
+    from md5 import md5
 
 def _validate_md5(egg_name, data):
     if egg_name in md5_data:
         digest = md5(data).hexdigest()
         if digest != md5_data[egg_name]:
-            print >>sys.stderr, (
-                "md5 validation of %s failed!  (Possible download problem?)"
-                % egg_name
-            )
+            print("md5 validation of {0} failed!  (Possible download problem?)".format(egg_name), file=sys.stderr)
             sys.exit(2)
     return data
 
@@ -88,21 +89,20 @@ def use_setuptools(
     def do_download():
         egg = download_setuptools(version, download_base, to_dir, download_delay)
         sys.path.insert(0, egg)
-        import setuptools; setuptools.bootstrap_install_from = egg
+        import setuptools;
+        setuptools.bootstrap_install_from = egg
     try:
         import pkg_resources
     except ImportError:
         return do_download()       
     try:
         pkg_resources.require("setuptools>="+version); return
-    except pkg_resources.VersionConflict, e:
+    except pkg_resources.VersionConflict as e:
         if was_imported:
-            print >>sys.stderr, (
-            "The required version of setuptools (>=%s) is not available, and\n"
-            "can't be installed while this script is running. Please install\n"
-            " a more recent version first, using 'easy_install -U setuptools'."
-            "\n\n(Currently using %r)"
-            ) % (version, e.args[0])
+            print("The required version of setuptools (>={0}) is not available, and\n" \
+                  "can't be installed while this script is running. Please install\n" \
+                  " a more recent version first, using 'easy_install -U setuptools'." \
+                  "\n\n(Currently using {1})".format(version, e.args[0]), file=sys.stderr)
             sys.exit(2)
         else:
             del pkg_resources, sys.modules['pkg_resources']    # reload ok
@@ -121,7 +121,7 @@ def download_setuptools(
     with a '/'). `to_dir` is the directory where the egg will be downloaded.
     `delay` is the number of seconds to pause before an actual download attempt.
     """
-    import urllib2, shutil
+    import urllib2
     egg_name = "setuptools-%s-py%s.egg" % (version,sys.version[:3])
     url = download_base + egg_name
     saveto = os.path.join(to_dir, egg_name)
@@ -158,40 +158,6 @@ and place it in this directory before rerunning this script.)
     return os.path.realpath(saveto)
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 def main(argv, version=DEFAULT_VERSION):
     """Install or upgrade setuptools and EasyInstall"""
     try:
@@ -208,10 +174,8 @@ def main(argv, version=DEFAULT_VERSION):
                 os.unlink(egg)
     else:
         if setuptools.__version__ == '0.0.1':
-            print >>sys.stderr, (
-            "You have an obsolete version of setuptools installed.  Please\n"
-            "remove it from your system entirely before rerunning this script."
-            )
+            print("You have an obsolete version of setuptools installed.  Please\n" \
+                  "remove it from your system entirely before rerunning this script.", file=sys.stderr)
             sys.exit(2)
 
     req = "setuptools>="+version
@@ -230,8 +194,8 @@ def main(argv, version=DEFAULT_VERSION):
             from setuptools.command.easy_install import main
             main(argv)
         else:
-            print "Setuptools version",version,"or greater has been installed."
-            print '(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)'
+            print('Setuptools version {0} or greater has been installed.'.format(version))
+            print('(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)')
 
 def update_md5(filenames):
     """Update our built-in md5 registry"""


### PR DESCRIPTION
config.py:
  - Fixed keyword -> variable name clashes
  - Fixed string builder to use newer .format()

testNestedDict.py:
  - Fixed tests to be compatible with Py3 dict.keys()/.items() now returns a "view" so needs to be wrapped in list() for compare

testUtils.py:
  - Fxied tests to be compatible with Py3, replaced base/child class with newer class types, corrected call to same_type to pass class object.